### PR TITLE
Update example to use Operation hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+server/boot/create-car.js

--- a/README.md
+++ b/README.md
@@ -162,27 +162,30 @@ Models:  [ 'User', 'AccessToken', 'ACL', 'RoleMapping', 'Role', 'car' ]
 ...
 ```
 
-###7. Define a model hook
+###7. Define a model operation hook
 
-Define [a model hook in `car.js`](/common/models/car.js#L27-L31).
+Define [a model operation hook in `car.js`](/common/models/car.js#L27-L35).
+
+Copy the `create-car.js` script to the `server/boot` directory.
+
+```
+cp examples/async-boot-script/create-car.js server/boot/
+```
 
 Restart the server.
-
-```
-./bin/remote-method-request
-```
 
 You should see:
 
 ```
 ...
 About to save a car instance: { make: 'honda', model: 'civic' }
+A `car` instance has been created from a boot script: { make: 'honda', model: 'civic', id: 1 }
 ...
 ```
 
-This model hook is triggered **before** saving any `car` model instance.
+This model operation hook is triggered **before** saving any `car` model instance.
 
-> Many other hooks are available, such as `afterInitialize`, `beforeValidate`, `beforeDestroy`, etc. See the [model hooks documentation](http://docs.strongloop.com/display/LB/Model+hooks) and [`loopback-faq-model-hooks`](https://github.com/strongloop/loopback-faq-model-hooks) for more information.
+> Many other operation hooks are available, such as `access`, `before save`, `after save`, `before delete`, and `after delete`. See the [model operation hooks documentation](http://docs.strongloop.com/display/public/LB/Operation+hooks) for more information.
 
 ###8. Add pre-processing middleware
 

--- a/common/models/car.js
+++ b/common/models/car.js
@@ -25,8 +25,12 @@ module.exports = function(Car) {
   });
 
   // model hook
-  Car.beforeSave = function(next, model) {
-    console.log('About to save a car instance:', model);
+  Car.observe('before save', function(ctx, next) {
+    if (ctx.instance) {
+      console.log('About to save a car instance:', ctx.instance);
+    } else {
+      console.log('About to update cars that match the query %j:', ctx.where);
+    }
     next();
-  };
+  });
 };

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "main": "server/server.js",
   "scripts": {
-    "pretest": "jshint ."
+    "pretest": "jshint .",
+    "start": "slc run"
   },
   "dependencies": {
     "compression": "^1.0.3",

--- a/server/middleware/datetime.js
+++ b/server/middleware/datetime.js
@@ -1,7 +1,7 @@
 module.exports = function() {
   return function datetime(req, res, next) {
-    console.log('Date time middleware triggered.')
+    console.log('Date time middleware triggered.');
 
     res.json({datetime: new Date()});
-  }
+  };
 };

--- a/server/middleware/tracker.js
+++ b/server/middleware/tracker.js
@@ -12,5 +12,5 @@ module.exports = function() {
     });
 
     next();
-  }
+  };
 };


### PR DESCRIPTION
moved the example from model hooks `Car.beforeSave` to operation hooks
`Car.observe(‘before save’, …)`

Updated the package.json so you can use `npm start` as a command

Updated the README to reference the new operation hook.  I also added a
note to copy the `create-car.js` file from the `examples` directory as
it wasn’t obvious.  The README could still use some real work to make
it cleaner and more obvious but this at least gets it working with
operation hooks instead of model hooks.

The README in the `examples` folder suggests copying over the server.js
file as well as the `create-car.js` which doesn’t seem necessary.

Also added the `server/boot/create-car.js` to the .gitignore file so
you can follow the instructions without git complaining you created a new file.